### PR TITLE
fix: 🐛 Fragment名変更に伴うビルドできない不具合の修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchFragment.kt
@@ -54,7 +54,7 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
 
     fun gotoRepositoryFragment(item: Item) {
         val action = SearchFragmentDirections
-            .actionRepositoriesFragmentToRepositoryFragment(item = item)
+            .actionSearchFragmentToRepositoryFragment(item = item)
         findNavController().navigate(action)
     }
 }


### PR DESCRIPTION
## Overview

[- close #TBD](https://github.com/charden/android-engineer-codecheck/pull/13) で発生させたビルド不具合の修正