### PR TITLE
 CQS 原則違反があるため、検索部分と表示部分の分離

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.3.5'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.2"
     implementation 'io.ktor:ktor-client-android:1.6.4'
     testImplementation 'io.ktor:ktor-client-mock:1.6.4'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.5'
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.2"
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.2'
     implementation 'io.ktor:ktor-client-android:1.6.4'
     testImplementation 'io.ktor:ktor-client-mock:1.6.4'
 

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/codecheck/pages/SearchPage.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/codecheck/pages/SearchPage.kt
@@ -34,6 +34,8 @@ class SearchPage {
      */
     fun clickSearch(): SearchPage {
         onView(withId(R.id.searchInputText)).perform(ViewActions.pressImeActionButton())
+        //TODO: 一時的にsleepで対応する テストが遅くなるので修正する
+        Thread.sleep(2000)
         return this
     }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchFragment.kt
@@ -8,14 +8,13 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
-import io.ktor.client.*
-import io.ktor.client.engine.android.*
 import jp.co.yumemi.android.codecheck.databinding.FragmentSearchBinding
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * 検索画面
@@ -44,13 +43,17 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
             .setOnEditorActionListener { editText, action, _ ->
                 if (action == EditorInfo.IME_ACTION_SEARCH) {
                     val inputText = editText.text.toString()
-                    val searchResults = viewModel.searchResults(inputText)
-                    adapter.submitList(searchResults)
+                    viewModel.search(inputText)
+
 
                     return@setOnEditorActionListener true
                 }
                 return@setOnEditorActionListener false
             }
+
+        lifecycleScope.launch {
+            viewModel.result.collect { result -> adapter.submitList(result) }
+        }
 
         binding.recyclerView.also {
             it.layoutManager = layoutManager

--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/SearchViewModel.kt
@@ -4,10 +4,11 @@
 package jp.co.yumemi.android.codecheck
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -17,6 +18,9 @@ import javax.inject.Inject
 @HiltViewModel
 class SearchViewModel @Inject constructor(private val repository: ItemRepositoryImpl) : ViewModel() {
 
+    private val _result = MutableStateFlow<List<Item>>(emptyList())
+    val result: StateFlow<List<Item>> = _result
+
     /**
      * GitHubのAPIからレポジトリを検索
      *
@@ -24,11 +28,11 @@ class SearchViewModel @Inject constructor(private val repository: ItemRepository
      *
      * @return  List<Item> レポジトリ検索結果
      */
-    fun searchResults(inputText: String): List<Item> = runBlocking {
-        if (inputText == "") return@runBlocking mutableListOf<Item>()
+    fun search(inputText: String) {
+        if (inputText == "") return
 
-        return@runBlocking GlobalScope.async {
-            return@async repository.fetchRepositories(inputText)
-        }.await()
+        viewModelScope.launch {
+            _result.value = repository.fetchRepositories(inputText)
+        }
     }
 }

--- a/app/src/test/kotlin/jp/co/yumemi/android/codecheck/SearchViewModelTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/codecheck/SearchViewModelTest.kt
@@ -2,55 +2,49 @@ package jp.co.yumemi.android.codecheck
 
 import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SearchViewModelTest {
     private lateinit var viewModel: SearchViewModel
 
     @Before
-    fun setup() {
+    fun setUp() {
+        val dispatcher = UnconfinedTestDispatcher()
+        Dispatchers.setMain(dispatcher)
         val api = MockApi()
-        val dataSource = ItemRemoteDataSource(api, Dispatchers.IO)
+        val dataSource = ItemRemoteDataSource(api, dispatcher)
         val repository = ItemRepositoryImpl(dataSource)
         viewModel = SearchViewModel(repository)
     }
 
-    private val baseItems = listOf(
-        Item(
-            "JetBrains/kotlin",
-            "https://avatars.githubusercontent.com/u/878437?v=4",
-            "Kotlin",
-            41802,
-            41802,
-            5162,
-            147
-        ),
-        Item(
-            "hussien89aa/KotlinUdemy",
-            "https://avatars.githubusercontent.com/u/7304399?v=4",
-            "Kotlin",
-            1462,
-            1462,
-            4936,
-            13
-        )
-    )
-
-    @Test
-    fun kotlinで検索したときに正常に返り値が得られること() {
-        runBlocking {
-            val result = viewModel.searchResults("kotlin")
-            assertEquals(result, baseItems)
-        }
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
     }
 
     @Test
+    fun kotlinで検索したときに正常に返り値が得られること() {
+        runTest {
+            viewModel.search("kotlin")
+            assertEquals(viewModel.result.value, MockApi().baseItems)
+        }
+    }
+
+
+    @Test
     fun 空文字で検索したときに正常に返り値が得られること() {
-        runBlocking {
-            val result = viewModel.searchResults("")
-            assertEquals(result, listOf<Item>())
+        runTest {
+            viewModel.search("")
+            assertEquals(viewModel.result.value, emptyList<Item>())
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5"
         classpath 'com.google.dagger:hilt-android-gradle-plugin:2.42'
 


### PR DESCRIPTION
## Issue

- #5 

## Overview

CQS 原則違反があるので検索ボタンを押した際には`searchResults`を実施
表示側はViewModelの値を監視するように変更