### PR TITLE
fix: 🐛 リリースビルドで難読化した場合に起動しない不具合を修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/codecheck/model/Item.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/codecheck/model/Item.kt
@@ -1,8 +1,10 @@
 package jp.co.yumemi.android.codecheck.model
 
 import android.os.Parcelable
+import androidx.annotation.Keep
 import kotlinx.parcelize.Parcelize
 
+@Keep
 @Parcelize
 data class Item(
     val name: String,


### PR DESCRIPTION
## Overview

リリースビルド時にクラッシュする不具合を修正

## Details (Optional)

```
06-20 15:03:50.625 16377 16377 E AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{jp.co.yumemi.android.codecheck/jp.co.yumemi.android.codecheck.ui.TopActivity}: java.lang.RuntimeException: Exception inflating jp.co.yumemi.android.codecheck:navigation/nav_graph line 25
06-20 15:03:50.625 16377 16377 E AndroidRuntime: Caused by: java.lang.RuntimeException: Exception inflating jp.co.yumemi.android.codecheck:navigation/nav_graph line 25
06-20 15:03:50.625 16377 16377 E AndroidRuntime: Caused by: java.lang.RuntimeException: java.lang.ClassNotFoundException: jp.co.yumemi.android.codecheck.model.Item
```

Itemクラスが難読化されてしまっているためnav_graph.xmlで指定されているものが読み込めない

https://developer.android.com/guide/navigation/navigation-pass-data?hl=ja

公式ガイドの通り`@Keep`のアノテーションをつける