### PR TITLE
chore: 🤖 dependabotnのpackage-ecosystemを設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Overview

dependabotのpackage-ecosystemが指定できていなかったので修正